### PR TITLE
fix: changed template for new feature on github issues tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,18 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## **Feature Summary**
+Provide a concise description of the new feature. What should it do?
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## **Problem or Motivation**
+Explain why this feature is needed. What problem does it solve?
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## **Proposed Solution**
+Describe your proposed solution or implementation idea.
+Optional: Include screenshots, sketches, or mockups
 
-**Additional context**
+## **Additional context**
 Add any other context or screenshots about the feature request here.
 
-**Things you need to know**
-Please ensure that you have read the document [here](https://cse110-sp25-group18.github.io/guides/workflow/)
+
 


### PR DESCRIPTION
## What does this PR do and why?
fixes template for github issues "new feature"

Fixes # 0

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## Screenshots or screen recordings

<img width="658" height="400" alt="Screenshot 2025-09-30 at 2 58 47 PM" src="https://github.com/user-attachments/assets/2e73bc03-a40c-453a-8b90-1eab12fd6a0b" />

